### PR TITLE
Add index.d.ts file for TypeScript compatibility

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -1,0 +1,1 @@
+declare module 'mongoose-valid8';


### PR DESCRIPTION
Adding this file allows you to use mongoose-valid8 in TypeScript files using import syntax instead of the require syntax. For example:

import { model, Schema } from 'mongoose-valid8';
